### PR TITLE
Adding hello world example

### DIFF
--- a/hello-world/hello.sh.yml
+++ b/hello-world/hello.sh.yml
@@ -1,0 +1,9 @@
+testtype: singlesource
+scheduler: local
+description: Hello World Buildtest Example
+maintainer:
+- vsoch
+
+program:
+  source: hello.sh
+

--- a/hello-world/src/hello.sh
+++ b/hello-world/src/hello.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+printf "Hello Buildtest\n"


### PR DESCRIPTION
This pull request will address #1 , specifically adding a hello world example to start the user out. Before this is merged we need to:

 - [ ] add the correct (a simplified) test type to buildtest that can be stated here
 - [ ] add a key to the test config (@shahzebsiddiqui can you link the issue here)?

Signed-off-by: vsoch <vsochat@stanford.edu>